### PR TITLE
Typecheck extend blocks, method calls

### DIFF
--- a/dls/src/main.rs
+++ b/dls/src/main.rs
@@ -468,10 +468,10 @@ impl Server {
                                     suhmm_tp = None;
                                 },
                                 MockStateCommand::Save => {
-                                    let suhmm_tp = suhmm_tp.as_mut().expect("expected suhmm tp after receiving \"save\" command");
-                                    suhmm_tp.save();
+                                    let tp = suhmm_tp.as_mut().expect("expected suhmm tp after receiving \"save\" command");
+                                    tp.save();
+                                    suhmm_tp = None;
                                 }
-
                             }
                         }
                         let tp: &mut dyn TypeProvider = if let Some(tp) = &mut suhmm_tp { tp } else {

--- a/dls/src/main.rs
+++ b/dls/src/main.rs
@@ -493,12 +493,12 @@ impl Server {
                     }
                 }
         
+                drop(tp_ref);
                 salf.flush_diagnostics(&mut driver.write(), path);
                 if !driver.read().diag.has_failed() {
                     driver.build_mir(&*tp.borrow());
                     salf.flush_diagnostics(&mut driver.write(), path);
                 }
-                drop(tp_ref);
                 tp.into_inner()
             });
     

--- a/dls/src/main.rs
+++ b/dls/src/main.rs
@@ -468,7 +468,8 @@ impl Server {
                                     suhmm_tp = None;
                                 },
                                 MockStateCommand::Save => {
-                                    todo!("saving mock type provider results is not yet supported");
+                                    let suhmm_tp = suhmm_tp.as_mut().expect("expected suhmm tp after receiving \"save\" command");
+                                    suhmm_tp.save();
                                 }
 
                             }

--- a/dls/src/main.rs
+++ b/dls/src/main.rs
@@ -7,7 +7,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use libdusk::ast::{Item, Expr};
 use libdusk::error::DiagnosticKind;
 use libdusk::new_code::NewCode;
-use libdusk::type_provider::{RealTypeProvider, TypeProvider};
+use libdusk::type_provider::{RealTypeProvider, TypeProvider, MockStateCommand, MockTypeProvider};
 use lsp_server::{Connection, Message, Request, RequestId, ExtractError, Notification, Response};
 use lsp_types::notification::{PublishDiagnostics, DidOpenTextDocument, Notification as NotificationTrait, DidChangeTextDocument, DidCloseTextDocument};
 use lsp_types::request::{Completion, ResolveCompletionItem, HoverRequest};
@@ -448,16 +448,40 @@ impl Server {
 
                 driver.write().initialize_tir();
         
-                let mut tp = driver.read().make_real_type_provider();
+                let tp = RefCell::new(driver.read().make_real_type_provider());
+                let mut tp_ref = tp.borrow_mut();
+                let mut suhmm_tp = None;
                 let mut new_code = NewCode::placeholder();
+                let mut last_typecheck_succeeded = true;
                 loop {
                     let mut driver_write = driver.write();
-                    if let Ok(Some(units)) = driver_write.build_more_tir() {
+                    if let Ok(Some(units)) = driver_write.build_more_tir(last_typecheck_succeeded) {
                         drop(driver_write);
+                        for command in &units.commands {
+                            match command {
+                                MockStateCommand::Mock => {
+                                    assert!(suhmm_tp.is_none());
+                                    drop(suhmm_tp);
+                                    suhmm_tp = Some(MockTypeProvider::new(&mut *tp_ref));
+                                },
+                                MockStateCommand::Discard => {
+                                    suhmm_tp = None;
+                                },
+                                MockStateCommand::Save => {
+                                    todo!("saving mock type provider results is not yet supported");
+                                }
+
+                            }
+                        }
+                        let tp: &mut dyn TypeProvider = if let Some(tp) = &mut suhmm_tp { tp } else {
+                            suhmm_tp = None;
+                            &mut *tp_ref
+                        };
                         // Typechecking can lead to expressions being evaluated, which in turn can result in new AST being
                         // added. Therefore, we take a snapshot before typechecking.
                         let before = driver.read().take_snapshot();
-                        if driver.type_check(&units, &mut tp, new_code).is_err() {
+                        last_typecheck_succeeded = !driver.type_check(&units, tp, new_code).is_err();
+                        if !last_typecheck_succeeded && !units.is_suhmm {
                             break;
                         }
                         new_code = driver.read().get_new_code_since(before);
@@ -470,10 +494,11 @@ impl Server {
         
                 salf.flush_diagnostics(&mut driver.write(), path);
                 if !driver.read().diag.has_failed() {
-                    driver.build_mir(&tp);
+                    driver.build_mir(&*tp.borrow());
                     salf.flush_diagnostics(&mut driver.write(), path);
                 }
-                tp
+                drop(tp_ref);
+                tp.into_inner()
             });
     
             tp

--- a/dusk/src/main.rs
+++ b/dusk/src/main.rs
@@ -146,10 +146,10 @@ fn dusk_main(opt: Opt, program_args: Option<&[OsString]>) {
                         suhmm_tp = None;
                     },
                     MockStateCommand::Save => {
-                        let suhmm_tp = suhmm_tp.as_mut().expect("expected suhmm tp after receiving \"save\" command");
-                        suhmm_tp.save();
+                        let tp = suhmm_tp.as_mut().expect("expected suhmm tp after receiving \"save\" command");
+                        tp.save();
+                        suhmm_tp = None;
                     }
-
                 }
             }
             let tp: &mut dyn TypeProvider = if let Some(tp) = &mut suhmm_tp { tp } else {

--- a/dusk/src/main.rs
+++ b/dusk/src/main.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, ArgEnum};
 use libdusk::interpreter::{InterpMode, restart_interp};
 use libdusk::mir::{FunctionRef, FuncId};
+use libdusk::type_provider::{MockStateCommand, MockTypeProvider, TypeProvider};
+use std::cell::RefCell;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::BufWriter;
@@ -123,19 +125,48 @@ fn dusk_main(opt: Opt, program_args: Option<&[OsString]>) {
 
     begin_phase!(Typecheck);
     driver.write().initialize_tir();
-    let mut tp = driver.read().make_real_type_provider();
+    let tp = RefCell::new(driver.read().make_real_type_provider());
+    let mut tp_ref = tp.borrow_mut();
+    let mut suhmm_tp = None;
     let mut new_code = NewCode::placeholder();
+    let mut last_typecheck_succeeded = true;
     loop {
         let mut driver_write = driver.write();
-        if let Ok(Some(units)) = driver_write.build_more_tir() {
+        if let Ok(Some(units)) = driver_write.build_more_tir(last_typecheck_succeeded) {
             drop(driver_write);
+
+            for command in &units.commands {
+                match command {
+                    MockStateCommand::Mock => {
+                        assert!(suhmm_tp.is_none());
+                        drop(suhmm_tp);
+                        suhmm_tp = Some(MockTypeProvider::new(&mut *tp_ref));
+                    },
+                    MockStateCommand::Discard => {
+                        suhmm_tp = None;
+                    },
+                    MockStateCommand::Save => {
+                        todo!("saving mock type provider results is not yet supported");
+                    }
+
+                }
+            }
+            let tp: &mut dyn TypeProvider = if let Some(tp) = &mut suhmm_tp { tp } else {
+                suhmm_tp = None;
+                &mut *tp_ref
+            };
+
             dvd_ipc::send(|| DvdMessage::WillTypeCheckSet);
+
             // Typechecking can lead to expressions being evaluated, which in turn can result in new AST being
             // added. Therefore, we take a snapshot before typechecking.
             let before = driver.read().take_snapshot();
-            if driver.type_check(&units, &mut tp, new_code).is_err() {
+            last_typecheck_succeeded = !driver.type_check(&units, tp, new_code).is_err();
+            if !last_typecheck_succeeded && !units.is_suhmm {
                 break;
             }
+
+
             new_code = driver.read().get_new_code_since(before);
             dvd_ipc::send(|| DvdMessage::DidTypeCheckSet);
             // { flush_diagnostics(&mut driver.write()); }
@@ -143,6 +174,9 @@ fn dusk_main(opt: Opt, program_args: Option<&[OsString]>) {
             break;
         }
     }
+
+    drop(tp_ref);
+    let tp = tp.into_inner();
 
     flush_diagnostics(&mut driver.write());
     if driver.read().diag.check_for_failure() { return; }

--- a/dusk/src/main.rs
+++ b/dusk/src/main.rs
@@ -146,7 +146,8 @@ fn dusk_main(opt: Opt, program_args: Option<&[OsString]>) {
                         suhmm_tp = None;
                     },
                     MockStateCommand::Save => {
-                        todo!("saving mock type provider results is not yet supported");
+                        let suhmm_tp = suhmm_tp.as_mut().expect("expected suhmm tp after receiving \"save\" command");
+                        suhmm_tp.save();
                     }
 
                 }

--- a/libdusk/src/ast.rs
+++ b/libdusk/src/ast.rs
@@ -49,6 +49,7 @@ define_index_type!(pub struct GenericContextNsId = u32;);
 define_index_type!(pub struct GenericParamId = u32;);
 define_index_type!(pub struct TypeVarId = u32;);
 define_index_type!(pub struct ExternModId = u32;);
+define_index_type!(pub struct ExtendBlockId = u32;);
 define_index_type!(pub struct GenericCtxId = u32;);
 define_index_type!(pub struct LoopId = u32;);
 define_index_type!(pub struct IntrinsicId = u32;);
@@ -163,6 +164,12 @@ pub struct DeclRef {
     pub expr: ExprId,
 }
 
+#[derive(Debug, Clone)]
+pub struct ExtendBlock {
+    pub extendee: ExprId,
+    pub methods: Vec<DeclId>,
+}
+
 #[derive(Debug)]
 pub struct ExternMod {
     pub library_path: ExprId,
@@ -244,7 +251,7 @@ pub enum Expr {
         fields: Vec<FieldAssignment>,
         id: StructLitId,
     },
-    ExtendBlock { extendee: ExprId, methods: Vec<DeclId> },
+    ExtendBlock { extendee: ExprId, id: ExtendBlockId },
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -546,6 +553,7 @@ pub struct Ast {
     pub structs: IndexVec<StructId, Struct>,
     pub enums: IndexVec<EnumId, Enum>,
     pub extern_mods: IndexVec<ExternModId, ExternMod>,
+    pub extend_blocks: IndexVec<ExtendBlockId, ExtendBlock>,
     pub struct_lits: IndexCounter<StructLitId>,
     pub type_vars: IndexCounter<TypeVarId>,
     pub expr_to_type_vars: IndexVec<ExprId, TypeVarId>,
@@ -1031,7 +1039,8 @@ impl Driver {
         self.add_expr(Expr::StructLit { ty, fields, id }, range)
     }
     pub fn extend_block(&mut self, extendee: ExprId, methods: Vec<DeclId>, range: SourceRange) -> ExprId {
-        self.add_expr(Expr::ExtendBlock { extendee, methods }, range)
+        let id = self.code.ast.extend_blocks.push(ExtendBlock { extendee, methods });
+        self.add_expr(Expr::ExtendBlock { extendee, id }, range)
     }
     pub fn error_expr(&mut self, range: SourceRange) -> ExprId {
         self.add_expr(Expr::Error, range)

--- a/libdusk/src/driver.rs
+++ b/libdusk/src/driver.rs
@@ -61,7 +61,7 @@ impl Driver {
     }
 }
 impl DriverRef<'_> {
-    pub fn eval_expr(&mut self, expr: ExprId, tp: &impl TypeProvider) -> Result<Const, EvalError> {
+    pub fn eval_expr(&mut self, expr: ExprId, tp: &dyn TypeProvider) -> Result<Const, EvalError> {
         let func = self.build_standalone_expr(expr, tp);
         let function_ref = FunctionRef::Ref(func);
         let val = self.call(function_ref, Vec::new(), Vec::new())?;

--- a/libdusk/src/interpreter.rs
+++ b/libdusk/src/interpreter.rs
@@ -591,7 +591,7 @@ fn nearest_multiple_of_16(val: i32) -> i32 { ((val - 1) | 15) + 1 }
 fn nearest_multiple_of_8(val: i32) -> i32 { ((val - 1) | 7) + 1 }
 
 impl Driver {
-    pub fn value_to_const(&mut self, val: Value, ty: Type, tp: &impl TypeProvider) -> Const {
+    pub fn value_to_const(&mut self, val: Value, ty: Type, tp: &dyn TypeProvider) -> Const {
         match ty {
             Type::Int { is_signed, .. } => {
                 let lit = val.as_big_int(is_signed);

--- a/libdusk/src/parser.rs
+++ b/libdusk/src/parser.rs
@@ -1568,7 +1568,7 @@ impl Driver {
         let decl_list = self.begin_list(p, TokenKind::could_begin_statement, [TokenKind::Semicolon], Some(TokenKind::CloseCurly));
 
         let mut methods = Vec::new();
-        let close_curly_range = loop {
+        let _close_curly_range = loop {
             match self.cur(p).kind {
                 TokenKind::Eof => {
                     self.diag.report_error("Unexpected end of file while parsing `extend` body", extend_range, "`extend` started here");

--- a/libdusk/src/parser.rs
+++ b/libdusk/src/parser.rs
@@ -1025,8 +1025,6 @@ impl Driver {
         for ident in idents {
             // Claim a GenericParamId for yourself, then set the `end` value to be one past the end
             let generic_param = self.ast.generic_params.next_idx();
-            // Make sure nobody interrupts this loop and creates an unrelated generic param
-            debug_assert_eq!(generic_params.ids.end, generic_param);
             generic_params.ids.end = generic_param + 1;
 
             generic_params.names.push(ident.symbol);

--- a/libdusk/src/tir/graph.rs
+++ b/libdusk/src/tir/graph.rs
@@ -686,6 +686,11 @@ impl Graph {
             if self.component_state.staged_components[&comp_id].meta_deps.is_empty() {
                 self.component_state.staged_components.remove(&comp_id);
 
+                // Re-register the component for being added to a unit
+                // Note that inserting to the real `outstanding_components` here instead of our local copy is intentional.
+                // Otherwise, previously-staged components would not be added properly.
+                self.component_state.outstanding_components.insert(comp_id);
+
                 // Update state to reflect the fact that the component no longer has meta-dependees
                 for i in 0..comp.items.len() {
                     let comp = &self.components[comp_id];

--- a/libdusk/src/tir/graph.rs
+++ b/libdusk/src/tir/graph.rs
@@ -47,24 +47,6 @@ pub struct Graph {
 
     /// Components that have not yet been added to a unit, or a mock unit
     outstanding_components: HashSet<CompId>,
-
-    /// Components whose items have been added to one or more mock units, but who have not yet
-    /// been added to a regular unit in their entirety
-    staged_components: HashMap<CompId, CompStageState>,
-
-    /// Components that have been added to a unit
-    included_components: HashSet<CompId>,
-}
-
-#[derive(Debug)]
-struct CompStageState {
-    /// Each element of this Vec is a Vec of meta-dependees that can form independent mock units with no dependencies on each other.
-    /// Each call to `solve()` pops another Vec off the end of the outer Vec, and adds them as mock units to the next set. When the
-    /// outer Vec is emptied, it means this component can be added to the next Unit proper.
-    ///
-    /// Example: consider the component below. The correct initial value of `meta_deps` would be [[std.str], [other_file, std, fs]]:
-    ///     other_file.foo(std.str.concat("Hello, ", "world!"), fs.read("HAASDASKJFD.txt"))
-    meta_deps: Vec<Vec<ItemId>>,
 }
 
 bitflags! {
@@ -94,11 +76,6 @@ impl Default for ComponentRelation {
 struct Component {
     items: Vec<ItemId>,
     deps: HashMap<CompId, ComponentRelation>,
-}
-
-#[derive(Debug, Default)]
-struct InternalUnit {
-    components: HashSet<CompId>,
 }
 
 impl Driver {
@@ -258,68 +235,6 @@ impl Graph {
 
     pub fn has_outstanding_components(&self) -> bool { !self.outstanding_components.is_empty() }
 
-
-    fn find_comps_without_outstanding_type_4_deps(&self, comps: &HashSet<CompId>, output: &mut HashSet<CompId>) {
-        'comps: for &comp_id in comps {
-            for (&dependee, &relation) in &self.components[comp_id].deps {
-                if relation == ComponentRelation::BEFORE && !self.included_components.contains(&dependee) {
-                    // Found a type 4 dependency, so we wont add this component. Continue to the next component.
-                    continue 'comps;
-                }
-            }
-            output.insert(comp_id);
-        }
-    }
-
-    fn remove_comps_with_outstanding_deps(&self, comps: &mut HashSet<CompId>) {
-        loop {
-            // Yay borrow checker
-            let comps_copy = comps.clone();
-            comps.retain(|&comp| {
-                for (&dependee, &relation) in &self.components[comp].deps {
-                    let in_current_unit = comps_copy.contains(&dependee);
-                    if
-                        relation == ComponentRelation::TYPE_2_3_FORWARD &&
-                        !in_current_unit &&
-                        !self.included_components.contains(&dependee)
-                    {
-                        return false;
-                    }
-                }
-                true
-            });
-
-            // If we didn't remove anything this iteration, we're done
-            if comps_copy.len() == comps.len() { break; }
-        }
-    }
-
-    fn stage_components(&mut self, comps: impl Iterator<Item=CompId>) {
-        let mut levels: HashMap<ItemId, u32> = HashMap::new();
-        for comp in comps {
-            let mut max_level = 0;
-            let items = &self.components[comp].items;
-            for &item in items {
-                let level = self.find_level(item, &mut levels, |item| self.global_meta_dependees.contains(&item));
-                max_level = max(max_level, level);
-            }
-    
-            let mut meta_deps = Vec::<Vec<ItemId>>::new();
-            meta_deps.resize_with(max_level as usize + 1, Default::default);
-    
-            for &item in items {
-                if !self.global_meta_dependees.contains(&item) { continue; }
-                // Invert the level so that lower levels can be popped off the end of the array
-                let level = max_level - levels[&item];
-                meta_deps[level as usize].push(item);
-            }
-
-            let state = CompStageState { meta_deps };
-            let old_val = self.staged_components.insert(comp, state);
-            assert!(old_val.is_none());
-        }
-    }
-
     fn item_has_meta_dependees(&self, item: ItemId) -> bool {
         self.meta_dependees.get(&item)
             .map(|dependees| !dependees.is_empty())
@@ -340,191 +255,14 @@ impl Graph {
     }
 
     pub fn solve(&mut self) -> Result<Levels, TirError> {
-        dvd::send(|| {
-            let mut outstanding_components: Vec<_> = self.outstanding_components.iter().copied().collect();
-            outstanding_components.sort();
-            DvdMessage::WillSolveTirGraph { outstanding_components }
-        });
-
-        // Get the outstanding components with meta-dependees in them
-        let mut meta_dep_components = HashSet::<CompId>::new();
-        for &comp in &self.outstanding_components {
-            let has_meta_dep = self.components[comp].items.iter()
-                .any(|item| self.global_meta_dependees.contains(item));
-            if has_meta_dep {
-                meta_dep_components.insert(comp);
-            }
-        }
-
-        // Get the components that depend (either directly or indirectly) on components with meta-dependees in them 
-        let excluded_components = {
-            let mut excluded_components = HashSet::new();
-            let mut potentially_excluded_components: HashSet<CompId> = self.outstanding_components
-                .difference(&meta_dep_components)
-                .copied()
-                .filter(|comp| !self.staged_components.contains_key(comp))
-                .collect();
-            let mut added_to_excluded_set = true;
-            while added_to_excluded_set {
-                added_to_excluded_set = false;
-                potentially_excluded_components.retain(|&comp_id| {
-                    let comp = &self.components[comp_id];
-                    for (dep, &relation) in &comp.deps {
-                        if !relation.contains(ComponentRelation::AFTER) && (meta_dep_components.contains(dep) || self.staged_components.contains_key(dep) || excluded_components.contains(dep)) {
-                            excluded_components.insert(comp_id);
-                            added_to_excluded_set = true;
-                            return false;
-                        }
-                    }
-                    true
-                });
-            }
-
-            excluded_components
-        };
-
-        dvd::send(|| {
-            let mut excluded_components: Vec<_> = meta_dep_components.union(&excluded_components).copied().collect();
-            excluded_components.sort();
-            DvdMessage::DidExcludeTirComponentsFromSubprogram(excluded_components)
-        });
-
-        // Temporarily remove all excluded components. Those that don't get staged will be added back after finding the units
-        self.outstanding_components.retain(|comp| !meta_dep_components.contains(comp) && !excluded_components.contains(comp));
-        if self.outstanding_components.is_empty() {
-            return Err(TirError::DependencyCycle);
-        }
-
-        let mut units = Vec::<InternalUnit>::new();
-        while !self.outstanding_components.is_empty() {
-            // Get all components that have no type 4 dependencies on outstanding components
-            let mut cur_unit_comps = HashSet::<CompId>::new();
-            self.find_comps_without_outstanding_type_4_deps(&self.outstanding_components, &mut cur_unit_comps);
-            // Whittle down the components to only those that have type 2 or 3 dependencies on each other, or included components
-            // (and not other outstanding components)
-            self.remove_comps_with_outstanding_deps(&mut cur_unit_comps);
-            assert!(!cur_unit_comps.is_empty(), "no viable components to add to TIR graph :( {:?}", units);
-            let mut cur_unit = InternalUnit::default();
-            cur_unit.components.extend(cur_unit_comps.iter());
-            for &comp in &cur_unit.components {
-                // Add intra-unit type 2 dependencies as type 1 dependencies, because they are equivalent after resolving units
-                let component = &self.components[comp];
-                for &item in &component.items {
-                    for &dep in &self.t2_dependees[item] {
-                        if cur_unit_comps.contains(&self.item_to_components[dep]) {
-                            self.dependees[item].push(dep);
-
-                            // NOTE: Adding to `dependers` here isn't required for ordinary operation
-                            // of the compiler, but it is used by the graph output code to decide
-                            // which items to cull.
-                            self.dependers[dep].push(item);
-                        }
-                    }
-                }
-                self.included_components.insert(comp);
-                self.outstanding_components.remove(&comp);
-            }
-            units.push(cur_unit);
-        }
-
-        // Stage viable components
-        {
-            // Get all meta-dep components that have no type 4 dependencies on outstanding components
-            let mut comps_to_stage = HashSet::<CompId>::new();
-            self.find_comps_without_outstanding_type_4_deps(&meta_dep_components, &mut comps_to_stage);
-
-            // Whittle down the components to only those that have type 2 or 3 dependencies on included components
-            // (and not other outstanding components, or each other)
-            self.remove_comps_with_outstanding_deps(&mut comps_to_stage);
-
-            // Add excluded components back to `outstanding_components`.
-            let all_excluded = meta_dep_components
-                .difference(&comps_to_stage)
-                .chain(&excluded_components);
-            self.outstanding_components.extend(all_excluded);
-
-            self.stage_components(comps_to_stage.into_iter());
-        }
-
-        let mut item_to_levels = HashMap::<ItemId, u32>::new();
-
-        for id in self.dependees.indices() {
-            self.find_level(id, &mut item_to_levels, |_| true);
-        }
-
-        let mut item_to_units = HashMap::<ItemId, u32>::new();
-
-        for (i, unit) in units.iter().enumerate() {
-            for &comp in &unit.components {
-                let components = &self.components[comp];
-                for &item in &components.items {
-                    item_to_units.insert(item, i as u32);
-                }
-            }
-        }
-
-        let mut mock_units = Vec::new();
-        // TODO: Borrow checker :(
-        let staged_comps_keys: Vec<_> = self.staged_components.keys().copied().collect();
-        'mock_staged_comps: for comp_id in staged_comps_keys {
-            // Check dependencies of the component before adding it to a mock unit. This is necessary because:
-            //   - Meta-dependers can add dependencies to themselves after a meta-dependee is mocked
-            //     (in fact, that's the whole point of all this)
-            //   - Meta-dependers can be in the same component as their meta-dependee
-            //   - Within a component, a second meta-dependee might exist that depends on the meta-depender (indeed,
-            //     the meta-depender itself might also be a meta-dependee). Therefore, we need to typecheck the
-            //     meta-depender's dependencies before we can mock it
-            let comp = &self.components[comp_id];
-            for (dep, &relation) in &comp.deps {
-                if !relation.contains(ComponentRelation::AFTER) && !self.included_components.contains(dep) {
-                    continue 'mock_staged_comps;
-                }
-            }
-
-            let meta_deps = self.staged_components.get_mut(&comp_id).unwrap().meta_deps.pop().unwrap();
-            for dep in meta_deps {
-                let mut item_to_levels: HashMap<ItemId, u32> = HashMap::new();
-
-                // Note: This will end up finding the levels of all items in the mock unit, because
-                // `dep` is the root of the tree, and there's only one component (therefore, all
-                // dependencies will be found)
-                let item_level = self.find_level(dep, &mut item_to_levels, |_| true);
-
-                let mut deps = HashSet::new();
-                self.get_deps(dep, &mut deps);
-
-                let mock_unit = MockUnit {
-                    item: dep,
-                    item_level,
-                    item_to_levels,
-
-                    // TODO: Remove this conversion; just make a Vec from the get-go (but first,
-                    //       find out if safe)
-                    deps: deps.into_iter().collect(),
-                };
-                mock_units.push(mock_unit);
-            }
-
-            if self.staged_components[&comp_id].meta_deps.is_empty() {
-                self.staged_components.remove(&comp_id);
-
-                // Re-register the component for being added to a unit
-                self.outstanding_components.insert(comp_id);
-
-                // Update state to reflect the fact that the component no longer has meta-dependees
-                for i in 0..comp.items.len() {
-                    let comp = &self.components[comp_id];
-                    let item = comp.items[i];
-                    self.remove_meta_dep_status(item);
-                }
-            }
-        }
-
-        dvd::send(|| DvdMessage::DidSolveTirGraph);
+        let item_to_levels = HashMap::new();
+        let item_to_units = HashMap::new();
+        let units = Vec::<InternalUnit>::new();
+        let mock_units = Vec::new();
         let components = &self.components;
         Ok(
             Levels {
-                item_to_levels: item_to_levels.clone(),
+                item_to_levels,
                 item_to_units,
                 units: units.into_iter()
                     .map(|unit| {
@@ -537,29 +275,14 @@ impl Graph {
             }
         )
     }
+}
 
-    fn get_deps(&self, item: ItemId, out: &mut HashSet<ItemId>) {
-        for &dependee in &self.dependees[item] {
-            out.insert(dependee);
-            self.get_deps(dependee, out);
-        }
-    }
-
-    fn remove_meta_dep_status(&mut self, item: ItemId) {
-        let was_removed = self.global_meta_dependees.remove(&item);
-        // Short-circuit the recursive chain
-        if !was_removed { return; }
-
-        for depender in &self.meta_dependers[&item] {
-            let dependees = self.meta_dependees.get_mut(depender).unwrap();
-            dependees.remove(&item);
-        }
-
-        for i in 0..self.dependees[item].len() {
-            let item = self.dependees[item][i];
-            self.remove_meta_dep_status(item);
-        }
-    }
+/// As the name implies, this representation of a unit is used internally in the graph
+/// implementation, to keep track of the components in a unit. It is later converted to a normal
+/// `Unit`.
+#[derive(Debug, Default)]
+struct InternalUnit {
+    components: HashSet<CompId>,
 }
 
 #[derive(Default, Debug)]

--- a/libdusk/src/tir/graph.rs
+++ b/libdusk/src/tir/graph.rs
@@ -254,7 +254,7 @@ impl Graph {
         items
     }
 
-    pub fn solve(&mut self) -> Result<AllLevels, TirError> {
+    pub fn solve(&mut self) -> Result<Levels, TirError> {
         let item_to_levels = HashMap::new();
         let item_to_units = HashMap::new();
         let units = Vec::<InternalUnit>::new();
@@ -281,10 +281,7 @@ impl Graph {
         };
 
         Ok(
-            AllLevels {
-                suhmm_dependees: Vec::new(),
-                main_levels,
-            }
+            main_levels
         )
     }
 }
@@ -295,19 +292,6 @@ impl Graph {
 #[derive(Debug, Default)]
 struct InternalUnit {
     components: HashSet<CompId>,
-}
-
-#[derive(Default, Debug)]
-pub struct AllLevels {
-    pub suhmm_dependees: Vec<SuhmmLevels>,
-    pub main_levels: Levels,
-}
-
-#[derive(Debug)]
-pub struct SuhmmLevels {
-    // The item id of the suhmm dependee
-    pub item: ItemId,
-    pub levels: Levels,
 }
 
 #[derive(Default, Debug)]

--- a/libdusk/src/tir/graph.rs
+++ b/libdusk/src/tir/graph.rs
@@ -47,6 +47,24 @@ pub struct Graph {
 
     /// Components that have not yet been added to a unit, or a mock unit
     outstanding_components: HashSet<CompId>,
+
+    /// Components whose items have been added to one or more mock units, but who have not yet
+    /// been added to a regular unit in their entirety
+    staged_components: HashMap<CompId, CompStageState>,
+
+    /// Components that have been added to a unit
+    included_components: HashSet<CompId>,
+}
+
+#[derive(Debug)]
+struct CompStageState {
+    /// Each element of this Vec is a Vec of meta-dependees that can form independent mock units with no dependencies on each other.
+    /// Each call to `solve()` pops another Vec off the end of the outer Vec, and adds them as mock units to the next set. When the
+    /// outer Vec is emptied, it means this component can be added to the next Unit proper.
+    ///
+    /// Example: consider the component below. The correct initial value of `meta_deps` would be [[std.str], [other_file, std, fs]]:
+    ///     other_file.foo(std.str.concat("Hello, ", "world!"), fs.read("HAASDASKJFD.txt"))
+    meta_deps: Vec<Vec<ItemId>>,
 }
 
 bitflags! {
@@ -235,6 +253,67 @@ impl Graph {
 
     pub fn has_outstanding_components(&self) -> bool { !self.outstanding_components.is_empty() }
 
+    fn find_comps_without_outstanding_type_4_deps(&self, comps: &HashSet<CompId>, output: &mut HashSet<CompId>) {
+        'comps: for &comp_id in comps {
+            for (&dependee, &relation) in &self.components[comp_id].deps {
+                if relation == ComponentRelation::BEFORE && !self.included_components.contains(&dependee) {
+                    // Found a type 4 dependency, so we wont add this component. Continue to the next component.
+                    continue 'comps;
+                }
+            }
+            output.insert(comp_id);
+        }
+    }
+
+    fn remove_comps_with_outstanding_deps(&self, comps: &mut HashSet<CompId>) {
+        loop {
+            // Yay borrow checker
+            let comps_copy = comps.clone();
+            comps.retain(|&comp| {
+                for (&dependee, &relation) in &self.components[comp].deps {
+                    let in_current_unit = comps_copy.contains(&dependee);
+                    if
+                        relation == ComponentRelation::TYPE_2_3_FORWARD &&
+                        !in_current_unit &&
+                        !self.included_components.contains(&dependee)
+                    {
+                        return false;
+                    }
+                }
+                true
+            });
+
+            // If we didn't remove anything this iteration, we're done
+            if comps_copy.len() == comps.len() { break; }
+        }
+    }
+
+    fn stage_components(&mut self, comps: impl Iterator<Item=CompId>) {
+        let mut levels: HashMap<ItemId, u32> = HashMap::new();
+        for comp in comps {
+            let mut max_level = 0;
+            let items = &self.components[comp].items;
+            for &item in items {
+                let level = self.find_level(item, &mut levels, |item| self.global_meta_dependees.contains(&item));
+                max_level = max(max_level, level);
+            }
+
+            let mut meta_deps = Vec::<Vec<ItemId>>::new();
+            meta_deps.resize_with(max_level as usize + 1, Default::default);
+
+            for &item in items {
+                if !self.global_meta_dependees.contains(&item) { continue; }
+                // Invert the level so that lower levels can be popped off the end of the array
+                let level = max_level - levels[&item];
+                meta_deps[level as usize].push(item);
+            }
+
+            let state = CompStageState { meta_deps };
+            let old_val = self.staged_components.insert(comp, state);
+            assert!(old_val.is_none());
+        }
+    }
+
     fn item_has_meta_dependees(&self, item: ItemId) -> bool {
         self.meta_dependees.get(&item)
             .map(|dependees| !dependees.is_empty())
@@ -254,18 +333,211 @@ impl Graph {
         items
     }
 
+    fn get_deps(&self, item: ItemId, out: &mut HashSet<ItemId>) {
+        for &dependee in &self.dependees[item] {
+            out.insert(dependee);
+            self.get_deps(dependee, out);
+        }
+    }
+
+    fn remove_meta_dep_status(&mut self, item: ItemId) {
+        let was_removed = self.global_meta_dependees.remove(&item);
+        // Short-circuit the recursive chain
+        if !was_removed { return; }
+
+        for depender in &self.meta_dependers[&item] {
+            let dependees = self.meta_dependees.get_mut(depender).unwrap();
+            dependees.remove(&item);
+        }
+
+        for i in 0..self.dependees[item].len() {
+            let item = self.dependees[item][i];
+            self.remove_meta_dep_status(item);
+        }
+    }
+
     pub fn solve(&mut self) -> Result<Levels, TirError> {
-        let item_to_levels = HashMap::new();
-        let item_to_units = HashMap::new();
-        let units = Vec::<InternalUnit>::new();
-        let mock_units = Vec::new();
-        let components = &self.components;
+        dvd::send(|| {
+            let mut outstanding_components: Vec<_> = self.outstanding_components.iter().copied().collect();
+            outstanding_components.sort();
+            DvdMessage::WillSolveTirGraph { outstanding_components }
+        });
 
-        // TODO: handle SUHMM dependencies
+        // Get the outstanding components with meta-dependees in them
+        let mut meta_dep_components = HashSet::<CompId>::new();
+        for &comp in &self.outstanding_components {
+            let has_meta_dep = self.components[comp].items.iter()
+                .any(|item| self.global_meta_dependees.contains(item));
+            if has_meta_dep {
+                meta_dep_components.insert(comp);
+            }
+        }
 
-        // TODO: handle components that don't depend on the mock results of unmocked meta-dependencies
+        // Get the components that depend (either directly or indirectly) on components with meta-dependees in them 
+        let excluded_components = {
+            let mut excluded_components = HashSet::new();
+            let mut potentially_excluded_components: HashSet<CompId> = self.outstanding_components
+                .difference(&meta_dep_components)
+                .copied()
+                .filter(|comp| !self.staged_components.contains_key(comp))
+                .collect();
+            let mut added_to_excluded_set = true;
+            while added_to_excluded_set {
+                added_to_excluded_set = false;
+                potentially_excluded_components.retain(|&comp_id| {
+                    let comp = &self.components[comp_id];
+                    for (dep, &relation) in &comp.deps {
+                        if !relation.contains(ComponentRelation::AFTER) && (meta_dep_components.contains(dep) || self.staged_components.contains_key(dep) || excluded_components.contains(dep)) {
+                            excluded_components.insert(comp_id);
+                            added_to_excluded_set = true;
+                            return false;
+                        }
+                    }
+                    true
+                });
+            }
 
-        // TODO: handle meta-dependencies, add mock units
+            excluded_components
+        };
+
+        dvd::send(|| {
+            let mut excluded_components: Vec<_> = meta_dep_components.union(&excluded_components).copied().collect();
+            excluded_components.sort();
+            DvdMessage::DidExcludeTirComponentsFromSubprogram(excluded_components)
+        });
+
+        // Temporarily remove all excluded components. Those that don't get staged will be added back after finding the units
+        self.outstanding_components.retain(|comp| !meta_dep_components.contains(comp) && !excluded_components.contains(comp));
+        if self.outstanding_components.is_empty() {
+            return Err(TirError::DependencyCycle);
+        }
+
+        let mut units = Vec::<InternalUnit>::new();
+        while !self.outstanding_components.is_empty() {
+            // Get all components that have no type 4 dependencies on outstanding components
+            let mut cur_unit_comps = HashSet::<CompId>::new();
+            self.find_comps_without_outstanding_type_4_deps(&self.outstanding_components, &mut cur_unit_comps);
+            // Whittle down the components to only those that have type 2 or 3 dependencies on each other, or included components
+            // (and not other outstanding components)
+            self.remove_comps_with_outstanding_deps(&mut cur_unit_comps);
+            assert!(!cur_unit_comps.is_empty(), "no viable components to add to TIR graph :( {:?}", units);
+            let mut cur_unit = InternalUnit::default();
+            cur_unit.components.extend(cur_unit_comps.iter());
+            for &comp in &cur_unit.components {
+                // Add intra-unit type 2 dependencies as type 1 dependencies, because they are equivalent after resolving units
+                let component = &self.components[comp];
+                for &item in &component.items {
+                    for &dep in &self.t2_dependees[item] {
+                        if cur_unit_comps.contains(&self.item_to_components[dep]) {
+                            self.dependees[item].push(dep);
+
+                            // NOTE: Adding to `dependers` here isn't required for ordinary operation
+                            // of the compiler, but it is used by the graph output code to decide
+                            // which items to cull.
+                            self.dependers[dep].push(item);
+                        }
+                    }
+                }
+                self.included_components.insert(comp);
+                self.outstanding_components.remove(&comp);
+            }
+            units.push(cur_unit);
+        }
+
+        // Stage viable components
+        {
+            // Get all meta-dep components that have no type 4 dependencies on outstanding components
+            let mut comps_to_stage = HashSet::<CompId>::new();
+            self.find_comps_without_outstanding_type_4_deps(&meta_dep_components, &mut comps_to_stage);
+
+            // Whittle down the components to only those that have type 2 or 3 dependencies on included components
+            // (and not other outstanding components, or each other)
+            self.remove_comps_with_outstanding_deps(&mut comps_to_stage);
+
+            // Add excluded components back to `outstanding_components`.
+            let all_excluded = meta_dep_components
+                .difference(&comps_to_stage)
+                .chain(&excluded_components);
+            self.outstanding_components.extend(all_excluded);
+
+            self.stage_components(comps_to_stage.into_iter());
+        }
+
+        let mut item_to_levels = HashMap::<ItemId, u32>::new();
+
+        for id in self.dependees.indices() {
+            self.find_level(id, &mut item_to_levels, |_| true);
+        }
+
+        let mut item_to_units = HashMap::<ItemId, u32>::new();
+
+        for (i, unit) in units.iter().enumerate() {
+            for &comp in &unit.components {
+                let components = &self.components[comp];
+                for &item in &components.items {
+                    item_to_units.insert(item, i as u32);
+                }
+            }
+        }
+
+        let mut mock_units = Vec::new();
+        // TODO: Borrow checker :(
+        let staged_comps_keys: Vec<_> = self.staged_components.keys().copied().collect();
+        'mock_staged_comps: for comp_id in staged_comps_keys {
+            // Check dependencies of the component before adding it to a mock unit. This is necessary because:
+            //   - Meta-dependers can add dependencies to themselves after a meta-dependee is mocked
+            //     (in fact, that's the whole point of all this)
+            //   - Meta-dependers can be in the same component as their meta-dependee
+            //   - Within a component, a second meta-dependee might exist that depends on the meta-depender (indeed,
+            //     the meta-depender itself might also be a meta-dependee). Therefore, we need to typecheck the
+            //     meta-depender's dependencies before we can mock it
+            let comp = &self.components[comp_id];
+            for (dep, &relation) in &comp.deps {
+                if !relation.contains(ComponentRelation::AFTER) && !self.included_components.contains(dep) {
+                    continue 'mock_staged_comps;
+                }
+            }
+
+            let meta_deps = self.staged_components.get_mut(&comp_id).unwrap().meta_deps.pop().unwrap();
+            for dep in meta_deps {
+                let mut item_to_levels: HashMap<ItemId, u32> = HashMap::new();
+
+                // Note: This will end up finding the levels of all items in the mock unit, because
+                // `dep` is the root of the tree, and there's only one component (therefore, all
+                // dependencies will be found)
+                let item_level = self.find_level(dep, &mut item_to_levels, |_| true);
+
+                let mut deps = HashSet::new();
+                self.get_deps(dep, &mut deps);
+
+                let mock_unit = MockUnit {
+                    item: dep,
+                    item_level,
+                    item_to_levels,
+
+                    // TODO: Remove this conversion; just make a Vec from the get-go (but first,
+                    //       find out if safe)
+                    deps: deps.into_iter().collect(),
+                };
+                mock_units.push(mock_unit);
+            }
+
+            if self.staged_components[&comp_id].meta_deps.is_empty() {
+                self.staged_components.remove(&comp_id);
+
+                // Re-register the component for being added to a unit
+                self.outstanding_components.insert(comp_id);
+
+                // Update state to reflect the fact that the component no longer has meta-dependees
+                for i in 0..comp.items.len() {
+                    let comp = &self.components[comp_id];
+                    let item = comp.items[i];
+                    self.remove_meta_dep_status(item);
+                }
+            }
+        }
+
+        dvd::send(|| DvdMessage::DidSolveTirGraph);
 
         let main_levels = Levels {
             item_to_levels,
@@ -273,7 +545,7 @@ impl Graph {
             units: units.into_iter()
                 .map(|unit| {
                     let items = unit.components.iter()
-                        .flat_map(|&comp| components[comp].items.iter().copied())
+                        .flat_map(|&comp| self.components[comp].items.iter().copied())
                         .collect();
                     Unit { items }
                 }).collect::<Vec<Unit>>(),

--- a/libdusk/src/tir/graph.rs
+++ b/libdusk/src/tir/graph.rs
@@ -101,6 +101,21 @@ struct InternalUnit {
     components: HashSet<CompId>,
 }
 
+impl Driver {
+    pub fn initialize_graph(&mut self) {
+        let mut deps = [
+            &mut self.tir.graph.dependees,
+            &mut self.tir.graph.t2_dependees,
+            &mut self.tir.graph.dependers
+        ];
+        for dep in &mut deps {
+            dep.resize_with(self.code.ast.items.len(), Vec::new);
+        }
+
+        self.tir.graph.item_to_components.resize_with(self.code.ast.items.len(), || CompId::new(u32::MAX as usize));
+    }
+}
+
 impl Graph {
     /// a and b must be in the *same* unit, and a must have a higher level than b
     pub fn add_type1_dep(&mut self, a: ItemId, b: ItemId) {
@@ -573,19 +588,4 @@ pub struct MockUnit {
     /// A collection of every item in this mock unit
     pub deps: Vec<ItemId>,
 
-}
-
-impl Driver {
-    pub fn initialize_graph(&mut self) {
-        let mut deps = [
-            &mut self.tir.graph.dependees,
-            &mut self.tir.graph.t2_dependees,
-            &mut self.tir.graph.dependers
-        ];
-        for dep in &mut deps {
-            dep.resize_with(self.code.ast.items.len(), Vec::new);
-        }
-
-        self.tir.graph.item_to_components.resize_with(self.code.ast.items.len(), || CompId::new(u32::MAX as usize));
-    }
 }

--- a/libdusk/src/type_provider.rs
+++ b/libdusk/src/type_provider.rs
@@ -5,8 +5,10 @@
 //! making changes to the values in the type provider, which we don't want to do. So we have two kinds of type
 //! providers, abstracted by the [TypeProvider] trait: [real](RealTypeProvider) and [mock](MockTypeProvider). There is
 //! only one real type provider, which stores the real answers. A mock type provider wraps the real type provider and
-//! provides a safe sandbox to temporarily make modifications that will soon be thrown away.
+//! provides a safe sandbox to temporarily make modifications that will soon be either thrown away, or in some cases
+//! saved to the underlying type provider.
 
+use std::mem;
 use std::collections::HashMap;
 
 use paste::paste;
@@ -70,6 +72,15 @@ macro_rules! forward_mock {
             }
         }
     };
+}
+macro_rules! forward_save {
+    ($salf:expr, $($doc:literal)* $field_name:ident, $fw_name:ident, $id_ty:ty, $val_ty:ty) => {{
+        paste! {
+            for (key, value) in mem::take(&mut $salf.$field_name) {
+                *$salf.base.[<$fw_name _mut>](key) = value;
+            }
+        }
+    }};
 }
 macro_rules! forward_real {
     ($($doc:literal)* $field_name:ident, $fw_name:ident, $id_ty:ty, $val_ty:ty) => {
@@ -148,6 +159,8 @@ macro_rules! declare_tp {
             }
 
             fn is_mock(&self) -> bool;
+
+            fn save(&mut self);
         }
         
         pub struct RealTypeProvider {
@@ -228,6 +241,8 @@ macro_rules! declare_tp {
             }
 
             fn is_mock(&self) -> bool { false }
+
+            fn save(&mut self) {}
         }
         
         pub struct MockTypeProvider<'base> {
@@ -242,7 +257,7 @@ macro_rules! declare_tp {
         }
 
         impl<'base> MockTypeProvider<'base> {
-            // base must ONLY be mutated in a resize operation
+            // base must ONLY be mutated in a resize or save operation
             pub fn new(base: &'base mut dyn TypeProvider) -> Self {
                 MockTypeProvider {
                     base,
@@ -269,6 +284,15 @@ macro_rules! declare_tp {
                 forward_mock!($field_name, $fn_name, $id_ty, $payload_ty);
             )*
             forward_mock!(eval_results, eval_result, ExprId, Const);
+
+            fn save(&mut self) {
+                $(
+                    forward_save!(self, $field_name, $fn_name, $id_ty, $payload_ty);
+                )*
+                for (key, value) in mem::take(&mut self.eval_results) {
+                    self.base.insert_eval_result(key, value);
+                }
+            }
         }
 
     }

--- a/libdusk/src/type_provider.rs
+++ b/libdusk/src/type_provider.rs
@@ -19,6 +19,7 @@ use crate::typechecker::{CastMethod, StructLit, constraints::ConstraintList, Ove
 use crate::index_vec::*;
 use crate::driver::Driver;
 use crate::new_code::NewCode;
+pub use crate::tir::MockStateCommand;
 
 /// The body of this macro defines the fields of the type provider. Each one maps to all of the following:
 /// - A field of type [`IndexVec<IdType, ValueType>`] in [RealTypeProvider]

--- a/libdusk/src/typechecker.rs
+++ b/libdusk/src/typechecker.rs
@@ -19,7 +19,7 @@ use crate::driver::{Driver, DriverRef};
 use crate::error::Error;
 use crate::new_code::NewCode;
 use crate::ty::BuiltinTraits;
-use crate::tir::{UnitItems, ExprNamespace, self, NameLookup, NewNamespaceRefKind, ExprMacroInfo, OverloadScope, AllUnits};
+use crate::tir::{UnitItems, ExprNamespace, self, NameLookup, NewNamespaceRefKind, ExprMacroInfo, OverloadScope, Units};
 
 use dusk_proc_macros::*;
 
@@ -1708,10 +1708,7 @@ impl Driver {
 }
 
 impl DriverRef<'_> {
-    pub fn type_check(&mut self, units: &AllUnits, tp: &mut RealTypeProvider, new_code: NewCode) -> Result<(), ()> {
-        // TODO: look at SUHMM units as well
-        let units = &units.main_units;
-
+    pub fn type_check(&mut self, units: &Units, tp: &mut dyn TypeProvider, new_code: NewCode) -> Result<(), ()> {
         tp.resize(&self.read(), new_code);
         for unit in &units.units {
             // Pass 1: propagate info down from leaves to roots

--- a/libdusk/src/typechecker.rs
+++ b/libdusk/src/typechecker.rs
@@ -19,7 +19,7 @@ use crate::driver::{Driver, DriverRef};
 use crate::error::Error;
 use crate::new_code::NewCode;
 use crate::ty::BuiltinTraits;
-use crate::tir::{Units, UnitItems, ExprNamespace, self, NameLookup, NewNamespaceRefKind, ExprMacroInfo, OverloadScope};
+use crate::tir::{UnitItems, ExprNamespace, self, NameLookup, NewNamespaceRefKind, ExprMacroInfo, OverloadScope, AllUnits};
 
 use dusk_proc_macros::*;
 
@@ -59,114 +59,114 @@ pub struct Overloads {
 }
 
 impl tir::Expr<tir::IntLit> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new()
             .with_trait_impls(BuiltinTraits::INT)
             .with_preferred_type(Type::i32());
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *tp.ty_mut(self.id) = driver.solve_constraints(tp, self.id).expect("Ambiguous type for integer literal").qual_ty.ty;
     }
 }
 
 impl tir::Expr<tir::DecLit> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new()
             .with_trait_impls(BuiltinTraits::DEC)
             .with_preferred_type(Type::f64());
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *tp.ty_mut(self.id) = driver.solve_constraints(tp, self.id).expect("Ambiguous type for decimal literal").qual_ty.ty;
     }
 }
 
 impl tir::Expr<tir::StrLit> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new()
             .with_trait_impls(BuiltinTraits::STR)
             .with_preferred_type(Type::u8().ptr());
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *tp.ty_mut(self.id) = driver.solve_constraints(tp, self.id).expect("Ambiguous type for string literal").qual_ty.ty;
     }
 }
 
 impl tir::Expr<tir::CharLit> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new()
             .with_trait_impls(BuiltinTraits::CHAR)
             .with_preferred_type(Type::u8().ptr());
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *tp.ty_mut(self.id) = driver.solve_constraints(tp, self.id).expect("Ambiguous type for character literal").qual_ty.ty;
     }
 }
 impl tir::Expr<tir::BoolLit> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Bool);
         *tp.ty_mut(self.id) = Type::Bool;
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::Expr<tir::Break> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Never);
         *tp.ty_mut(self.id) = Type::Never;
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::Expr<tir::Continue> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Never);
         *tp.ty_mut(self.id) = Type::Never;
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::Expr<tir::ConstExpr> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = self.0.clone();
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(ty.clone());
         *tp.ty_mut(self.id) = ty;
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::Expr<tir::ErrorExpr> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Error);
         *tp.ty_mut(self.id) = Type::Error;
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::GenericParam {
-    fn run_pass_1(&self, _driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, _driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *tp.decl_type_mut(self.id) = Type::Ty.into();
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::AssignedDecl {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = if let &Some(explicit_ty) = &self.explicit_ty {
             let explicit_ty = tp.get_evaluated_type(explicit_ty).clone();
             if let Some(err) = driver.can_unify_to(tp, self.root_expr, &explicit_ty.clone().into()).err() {
@@ -205,7 +205,7 @@ impl tir::AssignedDecl {
         tp.decl_type_mut(self.decl_id).ty = ty;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let decl_id = self.decl_id;
         let root_expr = self.root_expr;
         let ty = tp.fetch_decl_type(driver, decl_id, None).ty;
@@ -214,7 +214,7 @@ impl tir::AssignedDecl {
 }
 
 impl tir::PatternBinding {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let constraints = driver.get_constraints(tp, self.scrutinee);
         let scrutinee_ty = driver.solve_constraints(tp, constraints).expect("Ambiguous type for assigned declaration").qual_ty.ty;
         let mut binding_ty = None;
@@ -245,17 +245,17 @@ impl tir::PatternBinding {
         tp.decl_type_mut(self.decl_id).ty = binding_ty.unwrap();
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::Expr<tir::Assignment> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         driver.set_type(tp, self.id, Type::Void).unwrap();
         *tp.ty_mut(self.id) = Type::Void;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         if let Err(err) = driver.intersect_constraints_lopsided(tp, self.lhs, self.rhs) {
             match err {
                 AssignmentError::Immutable => {
@@ -269,13 +269,13 @@ impl tir::Expr<tir::Assignment> {
 }
 
 impl tir::Expr<tir::Cast> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = tp.get_evaluated_type(self.ty).clone();
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(ty.clone());
         *tp.ty_mut(self.id) = ty;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = tp.get_evaluated_type(self.ty).clone();
         // TODO: pass `self.ty` directly to can_unify_to() once its support for generics is more robust
         let ty_and_method: Result<(Type, Option<DeclId>, CastMethod), Vec<QualType>> = if let Ok(success) = driver.can_unify_to(tp, self.expr, &QualType::from(&ty)) {
@@ -341,12 +341,12 @@ impl tir::Expr<tir::Cast> {
 }
 
 impl tir::Expr<tir::While> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Void);
         *tp.ty_mut(self.id) = Type::Void;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         if driver.set_type(tp, self.condition, Type::Bool).is_err() {
             panic!("Expected boolean condition in while expression");
         }
@@ -354,7 +354,7 @@ impl tir::Expr<tir::While> {
 }
 
 impl tir::Expr<tir::For> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Void);
         *tp.ty_mut(self.id) = Type::Void;
 
@@ -439,7 +439,7 @@ impl tir::Expr<tir::For> {
         *tp.decl_type_mut(self.binding_decl) = QualType { ty: loop_binding_ty, is_mut };
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = tp.fetch_decl_type(driver, self.binding_decl, None).ty;
         driver.set_type(tp, self.lower_bound, ty.clone()).unwrap();
         driver.set_type(tp, self.upper_bound, ty).unwrap();
@@ -476,7 +476,7 @@ enum Exhaustion {
 }
 
 impl EnumExhaustion {
-    fn is_total(&self, driver: &Driver, scrutinee_ty: &Type, tp: &impl TypeProvider) -> bool {
+    fn is_total(&self, driver: &Driver, scrutinee_ty: &Type, tp: &dyn TypeProvider) -> bool {
         let enum_id = match scrutinee_ty {
             &Type::Enum(enum_id) => enum_id,
             _ => panic!("expected enum"),
@@ -503,7 +503,7 @@ impl EnumExhaustion {
         }
     }
 
-    fn make_total(&mut self, driver: &Driver, scrutinee_ty: &Type, catch_all_range: SourceRange, tp: &impl TypeProvider) {
+    fn make_total(&mut self, driver: &Driver, scrutinee_ty: &Type, catch_all_range: SourceRange, tp: &dyn TypeProvider) {
         let enum_id = match scrutinee_ty {
             &Type::Enum(enum_id) => enum_id,
             _ => panic!("expected enum"),
@@ -529,14 +529,14 @@ impl EnumExhaustion {
 }
 
 impl Exhaustion {
-    fn is_total(&self, driver: &Driver, scrutinee_ty: &Type, tp: &impl TypeProvider) -> bool {
+    fn is_total(&self, driver: &Driver, scrutinee_ty: &Type, tp: &dyn TypeProvider) -> bool {
         match self {
             Exhaustion::Enum(exhaustion) => exhaustion.is_total(driver, scrutinee_ty, tp),
             Exhaustion::Total => true,
         }
     }
 
-    fn make_total(&mut self, driver: &Driver, scrutinee_ty: &Type, catch_all_range: SourceRange, tp: &impl TypeProvider) {
+    fn make_total(&mut self, driver: &Driver, scrutinee_ty: &Type, catch_all_range: SourceRange, tp: &dyn TypeProvider) {
         match self {
             Exhaustion::Enum(exhaustion) => exhaustion.make_total(driver, scrutinee_ty, catch_all_range, tp),
             Exhaustion::Total => {},
@@ -545,7 +545,7 @@ impl Exhaustion {
 }
 
 impl tir::Expr<tir::Switch> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let scrutinee_ty = driver.solve_constraints(tp, self.scrutinee).expect("Ambiguous type for scrutinee in switch expression").qual_ty.ty;
         match scrutinee_ty {
             Type::Enum(id) => {
@@ -735,7 +735,7 @@ impl tir::Expr<tir::Switch> {
         *driver.get_constraints_mut(tp, self.id) = constraints;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let scrutinee_ty = driver.solve_constraints(tp, self.scrutinee)
             .unwrap_or(ConstraintSolution::error())
             .make_immutable();
@@ -749,17 +749,17 @@ impl tir::Expr<tir::Switch> {
 }
 
 impl tir::Expr<tir::ExplicitRet> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Never);
         *tp.ty_mut(self.id) = Type::Never;
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::Expr<tir::Module> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Mod);
         *tp.ty_mut(self.id) = Type::Mod;
 
@@ -776,7 +776,7 @@ impl tir::Expr<tir::Module> {
         }
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         // Set the type of the extern library path string
         if let Some(extern_library_path) = self.extern_library_path {
             let selected_type = string_types().into_iter()
@@ -790,7 +790,7 @@ impl tir::Expr<tir::Module> {
 }
 
 impl tir::Expr<tir::Enum> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = ConstraintList::new().with_type(Type::Ty);
         *tp.ty_mut(self.id) = Type::Ty;
         for &payload_ty in &self.variant_payload_tys {
@@ -815,7 +815,7 @@ impl tir::Expr<tir::Enum> {
         driver.set_type(tp, self.id, Type::Ty).unwrap();
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         for &variant_ty in &self.variant_payload_tys {
             let field_type = driver.solve_constraints(tp, variant_ty)
                 .unwrap_or(ConstraintSolution::error())
@@ -837,7 +837,7 @@ fn string_types() -> [Type; 3] {
 }
 
 impl tir::Expr<tir::DeclRef> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         // Initialize overloads
         let decl_ref = &driver.code.ast.decl_refs[self.decl_ref_id];
         let overload_decls = match driver.find_overloads(decl_ref.namespace, &NameLookup::Exact(decl_ref.name)) {
@@ -914,7 +914,7 @@ impl tir::Expr<tir::DeclRef> {
         *tp.overloads_mut(self.decl_ref_id) = Overloads { overloads, nonviable_overloads };
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = driver.solve_constraints(tp, self.id).unwrap_or(ConstraintSolution::error());
         *tp.ty_mut(self.id) = ty.qual_ty.ty.clone();
 
@@ -1004,7 +1004,7 @@ impl tir::Expr<tir::Call> {
             panic!("unexpected generic context '{:?}' for callee", generic_ctx);
         }
     }
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let decl_ref_id = self.decl_ref_id(driver);
 
         // Rule out function types that don't match the arguments
@@ -1093,7 +1093,7 @@ impl tir::Expr<tir::Call> {
             .with_maybe_preferred_type(pref);
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = driver.solve_constraints(tp, self.id)
             .unwrap_or(ConstraintSolution::error())
             .make_immutable();
@@ -1152,7 +1152,7 @@ impl tir::Expr<tir::Call> {
 }
 
 impl tir::Expr<tir::AddrOf> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let constraints = driver.get_constraints(tp, self.expr).filter_map(|ty| {
             if self.is_mut && !ty.is_mut { return None; }
             Some(
@@ -1164,7 +1164,7 @@ impl tir::Expr<tir::AddrOf> {
         *driver.get_constraints_mut(tp, self.id) = constraints;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let pointer_ty = driver.solve_constraints(tp, self.id)
             .unwrap_or(ConstraintSolution::error())
             .make_immutable();
@@ -1181,14 +1181,14 @@ impl tir::Expr<tir::AddrOf> {
 }
 
 impl tir::Expr<tir::Dereference> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let constraints = driver.get_constraints(tp, self.expr).filter_map(|ty| {
             ty.ty.deref().cloned()
         });
         *driver.get_constraints_mut(tp, self.id) = constraints;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let mut ty = driver.solve_constraints(tp, self.id).unwrap_or(ConstraintSolution::error());
         *tp.ty_mut(self.id) = ty.qual_ty.ty.clone();
 
@@ -1200,7 +1200,7 @@ impl tir::Expr<tir::Dereference> {
 }
 
 impl tir::Expr<tir::Pointer> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         if let Err(err) = driver.set_type(tp, self.id, Type::Ty) {
             let mut error = Error::new("Expected type operand to pointer operator");
             let range = driver.get_range(self.expr);
@@ -1222,7 +1222,7 @@ impl tir::Expr<tir::Pointer> {
         
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let expr_ty = driver.solve_constraints(tp, self.expr)
             .unwrap_or(ConstraintSolution::error())
             .make_immutable();
@@ -1235,8 +1235,8 @@ impl tir::Expr<tir::Pointer> {
 }
 
 impl tir::Expr<tir::FunctionTy> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
-        fn check_type(driver: &mut Driver, tp: &impl TypeProvider, ty: ExprId) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
+        fn check_type(driver: &mut Driver, tp: &dyn TypeProvider, ty: ExprId) {
             if let Some(err) = driver.can_unify_to(tp, ty, &Type::Ty.into()).err() {
                 let mut error = Error::new("Expected type");
                 let range = driver.get_range(ty);
@@ -1262,8 +1262,8 @@ impl tir::Expr<tir::FunctionTy> {
         driver.set_type(tp, self.id, Type::Ty).unwrap();
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
-        fn solve_ty(driver: &Driver, tp: &mut impl TypeProvider, ty: ExprId) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
+        fn solve_ty(driver: &Driver, tp: &mut dyn TypeProvider, ty: ExprId) {
             let expr_ty = driver.solve_constraints(tp, ty)
                 .unwrap_or(ConstraintSolution::error())
                 .make_immutable();
@@ -1282,7 +1282,7 @@ impl tir::Expr<tir::FunctionTy> {
 }
 
 impl tir::Expr<tir::Struct> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         for &field_ty in &self.field_tys {
             if let Some(err) = driver.can_unify_to(tp, field_ty, &Type::Ty.into()).err() {
                 let mut error = Error::new("Expected field type");
@@ -1305,7 +1305,7 @@ impl tir::Expr<tir::Struct> {
         driver.set_type(tp, self.id, Type::Ty).unwrap();
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         for &field_ty in &self.field_tys {
             let field_type = driver.solve_constraints(tp, field_ty)
                 .unwrap_or(ConstraintSolution::error())
@@ -1320,7 +1320,7 @@ impl tir::Expr<tir::Struct> {
 }
 
 impl tir::Expr<tir::StructLit> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         if let Some(err) = driver.can_unify_to(tp, self.ty, &Type::Ty.into()).err() {
             let mut error = Error::new("Expected struct type");
             let range = driver.get_range(self.ty);
@@ -1436,7 +1436,7 @@ impl tir::Expr<tir::StructLit> {
 
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = driver.solve_constraints(tp, self.id).unwrap();
 
         *tp.ty_mut(self.id) = ty.qual_ty.ty;
@@ -1451,7 +1451,7 @@ impl tir::Expr<tir::StructLit> {
 }
 
 impl tir::Expr<tir::If> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         if let Some(err) = driver.can_unify_to(tp, self.condition, &Type::Bool.into()).err() {
             let mut error = Error::new("Expected boolean condition in if expression");
             let range = driver.get_range(self.condition);
@@ -1482,7 +1482,7 @@ impl tir::Expr<tir::If> {
         *driver.get_constraints_mut(tp, self.id) = constraints;
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let condition_ty = driver.solve_constraints(tp, self.condition)
             .unwrap_or(ConstraintSolution::error())
             .make_immutable();
@@ -1498,11 +1498,11 @@ impl tir::Expr<tir::If> {
 }
 
 impl tir::Expr<tir::Do> {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         *driver.get_constraints_mut(tp, self.id) = driver.get_constraints(tp, self.terminal_expr).clone();
     }
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let solution = driver.solve_constraints(tp, self.id).expect("Ambiguous type for do expression");
         *tp.ty_mut(self.id) = solution.qual_ty.ty.clone();
         driver.get_constraints_mut(tp, self.terminal_expr).set_to(solution);
@@ -1510,7 +1510,7 @@ impl tir::Expr<tir::Do> {
 }
 
 impl tir::Stmt {
-    fn run_pass_1(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         if let Err(err) = driver.set_type(tp, self.root_expr, Type::Void) {
             if self.has_semicolon {
                 return;
@@ -1533,14 +1533,14 @@ impl tir::Stmt {
         }
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {
     }
 }
 
 impl tir::RetGroup {
-    fn run_pass_1(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {}
+    fn run_pass_1(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {}
 
-    fn run_pass_2(&self, driver: &mut Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&self, driver: &mut Driver, tp: &mut dyn TypeProvider) {
         let ty = tp.get_evaluated_type(self.ty).clone();
         for &expr in &self.exprs {
             if let Err(err) = driver.set_type(tp, expr, ty.clone()) {
@@ -1575,15 +1575,15 @@ impl tir::RetGroup {
 }
 
 impl tir::FunctionDecl {
-    fn run_pass_1(&self, driver: &Driver, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&self, driver: &Driver, tp: &mut dyn TypeProvider) {
         tp.set_decl_type_to_explicit_type_if_exists(driver, self.id);
     }
 
-    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut impl TypeProvider) {}
+    fn run_pass_2(&self, _driver: &mut Driver, _tp: &mut dyn TypeProvider) {}
 }
 
 impl Driver {
-    pub fn register_type_variables_for_decl_ref(&mut self, tp: &mut impl TypeProvider, expr: ExprId, decl_ref: DeclRefId, overload: DeclId, ty: Type) -> Type {
+    pub fn register_type_variables_for_decl_ref(&mut self, tp: &mut dyn TypeProvider, expr: ExprId, decl_ref: DeclRefId, overload: DeclId, ty: Type) -> Type {
         let decl = &self.tir.decls[overload];
         if decl.generic_params.is_empty() {
             return ty;
@@ -1630,7 +1630,7 @@ impl Driver {
         Type::Function(FunctionType { param_tys, has_c_variadic_param, return_ty })
     }
 
-    fn run_pass_1(&mut self, unit: &UnitItems, start_level: u32, tp: &mut impl TypeProvider) {
+    fn run_pass_1(&mut self, unit: &UnitItems, start_level: u32, tp: &mut dyn TypeProvider) {
         macro_rules! run_pass_1_flat {
             ($($name:ident$(,)*)+) => {
                 $(
@@ -1663,7 +1663,7 @@ impl Driver {
         run_pass_1_flat!(stmts);
     }
 
-    fn run_pass_2(&mut self, unit: &UnitItems, tp: &mut impl TypeProvider) {
+    fn run_pass_2(&mut self, unit: &UnitItems, tp: &mut dyn TypeProvider) {
         for level in (0..unit.num_levels()).rev() {
             macro_rules! run_pass_2 {
                 ($($name:ident$(,)*)+) => {
@@ -1693,7 +1693,7 @@ impl Driver {
         run_pass_2_flat!(int_lits, dec_lits, str_lits, char_lits, bool_lits, consts, generic_params, stmts, error_exprs, func_decls, breaks, continues);
     }
 
-    fn initialize_global_expressions(&self, tp: &mut impl TypeProvider) {
+    fn initialize_global_expressions(&self, tp: &mut dyn TypeProvider) {
         *self.get_constraints_mut(tp, ast::VOID_EXPR) = ConstraintList::new().with_type(Type::Void);
         *tp.ty_mut(ast::VOID_EXPR) = Type::Void;
         *self.get_constraints_mut(tp, ast::ERROR_EXPR) = ConstraintList::new().with_type(Type::Error);
@@ -1708,7 +1708,10 @@ impl Driver {
 }
 
 impl DriverRef<'_> {
-    pub fn type_check(&mut self, units: &Units, tp: &mut RealTypeProvider, new_code: NewCode) -> Result<(), ()> {
+    pub fn type_check(&mut self, units: &AllUnits, tp: &mut RealTypeProvider, new_code: NewCode) -> Result<(), ()> {
+        // TODO: look at SUHMM units as well
+        let units = &units.main_units;
+
         tp.resize(&self.read(), new_code);
         for unit in &units.units {
             // Pass 1: propagate info down from leaves to roots

--- a/samples/extend-blocks.dusk
+++ b/samples/extend-blocks.dusk
@@ -11,5 +11,6 @@ extend MyStruct {
 }
 
 fn main() {
-    
+    value :: MyStruct.new()
+    value.do_something_truly_amazing()
 }

--- a/samples/extend-blocks.dusk
+++ b/samples/extend-blocks.dusk
@@ -1,24 +1,24 @@
 MyStruct :: struct {}
 
 extend MyStruct {
-    // fn new(): MyStruct {
-    //     MyStruct {}
-    // }
+    fn new(): MyStruct {
+        MyStruct {}
+    }
 
     // TODO: add support for `self`, `self*` and `self *mut`, with no explicit type, as the first parameter
-    // fn do_something_truly_amazing(self: MyStruct) {
-    // }
+    fn do_something_truly_amazing(self: MyStruct) {
+    }
 
-    // fn do_something_normal_and_not_amazing() {
-    //     print("Doing something really normal")
-    // }
+    fn do_something_normal_and_not_amazing_at_all() {
+        print("Doing something really normal\n")
+    }
 }
 
 fn main() {
-    // value :: MyStruct.new()
-    // MyStruct.do_something_truly_amazing(value)
+    MyStruct.do_something_normal_and_not_amazing_at_all()
 
-
+    value :: MyStruct.new()
+    MyStruct.do_something_truly_amazing(value)
 
     // TODO: support calling instance methods:
     // value.do_something_truly_amazing()

--- a/samples/extend-blocks.dusk
+++ b/samples/extend-blocks.dusk
@@ -1,16 +1,25 @@
 MyStruct :: struct {}
 
 extend MyStruct {
-    fn new(): MyStruct {
-        MyStruct {}
-    }
+    // fn new(): MyStruct {
+    //     MyStruct {}
+    // }
 
     // TODO: add support for `self`, `self*` and `self *mut`, with no explicit type, as the first parameter
-    fn do_something_truly_amazing(self: MyStruct) {
-    }
+    // fn do_something_truly_amazing(self: MyStruct) {
+    // }
+
+    // fn do_something_normal_and_not_amazing() {
+    //     print("Doing something really normal")
+    // }
 }
 
 fn main() {
-    value :: MyStruct.new()
-    value.do_something_truly_amazing()
+    // value :: MyStruct.new()
+    // MyStruct.do_something_truly_amazing(value)
+
+
+
+    // TODO: support calling instance methods:
+    // value.do_something_truly_amazing()
 }


### PR DESCRIPTION
The goal of this PR is to make the TIR graph resolver and typechecker flexible enough to support the following use cases:
- Typechecking `extend` blocks
- (if I'm feeling ambitious) Change the semantics of type 3 dependencies, such that all statements in a function need to be typechecked only if it is about to be evaluated.
  - Translation to terms the graph resolver can understand: if there is type 4 dependency between some item `a` and another item `b`, then I need to traverse the dependencies of `b` to find any type 3 dependencies that exist. These all must be put into a unit strictly before the unit that `a` is put into.